### PR TITLE
Add enemy battles with attributes and styled dialogs

### DIFF
--- a/src/pygame_adventure.py
+++ b/src/pygame_adventure.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+# Postpone evaluation of type hints so forward references like `NPC` work
+
 import sys
 from dataclasses import dataclass, field
 from typing import List, Dict, Optional


### PR DESCRIPTION
## Summary
- incorporate abilities and class attributes into the Pygame adventure
- overlay all dialog choices on a Final Fantasy‑style blue gradient textbox with speaker name and portrait
- support a simple turn-based combat system and add an imp enemy in the Brig

## Testing
- `python3 -m py_compile src/pygame_adventure.py`
- `python3 -m py_compile src/main.py src/pygame_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_68563e620c308326b0aac97fe33e16dc