### PR TITLE
Restrict PC classes to fighter, rogue, mage, cleric

### DIFF
--- a/docs/vertical_slice_design.md
+++ b/docs/vertical_slice_design.md
@@ -4,7 +4,7 @@ This document outlines the scope for the prototype.
 
 ## Features
 
-* **Character Creation:** Choose a name and class (Fighter, Rogue, Mage).
+* **Character Creation:** Choose a name and class (Fighter, Rogue, Mage, Cleric).
 * **Exploration:** Navigate multiple text-based rooms connected by doors.
 * **Interactables:** Open chests and inspect objects to learn about the ship.
 * **Familiar Companion:** Discover a strange creature that can join you after a simple skill check.

--- a/nautiloid.c
+++ b/nautiloid.c
@@ -7,7 +7,7 @@
 #include <string.h>
 /*
  * TODO: port features from pygame_adventure.py
- * - Define class data for Healer, Beast and Demon
+ * - Define class data for Cleric, Beast and Demon
  * - Map attack and defense attributes per class
  * - Create NPC, Chest, Prop, Door and Room structs
  * - Implement create_rooms() to mirror Python rooms
@@ -102,7 +102,7 @@ static Ability const mage_abilities[] = {
     {.name = "Barrier", .target = "ally", .melee = false, .power = 3},
 };
 
-static Ability const healer_abilities[] = {
+static Ability const cleric_abilities[] = {
     {.name = "Smite", .target = "enemy", .melee = true, .power = 3},
     {.name = "Heal", .target = "ally", .melee = false, .power = 4},
 };
@@ -123,7 +123,7 @@ static ClassInfo const classes[] = {
      .attributes = {5, 8, 3, 10}},
     {.name = "Mage", .abilities = mage_abilities, .ability_count = 2,
      .attributes = {3, 5, 8, 8}},
-    {.name = "Healer", .abilities = healer_abilities, .ability_count = 2,
+    {.name = "Cleric", .abilities = cleric_abilities, .ability_count = 2,
      .attributes = {4, 4, 8, 10}},
     {.name = "Beast", .abilities = beast_abilities, .ability_count = 2,
      .attributes = {6, 6, 2, 8}},
@@ -470,8 +470,7 @@ int main(int argc, char *argv[]) {
 
     char name[64];
     text_input(renderer, font, "Enter your name:", name, (int)sizeof(name));
-    char const *class_names[] = {
-        "Fighter", "Rogue", "Mage", "Healer", "Beast", "Demon"};
+    char const *class_names[] = {"Fighter", "Rogue", "Mage", "Cleric"};
     int class_idx =
         menu_prompt(renderer, font, "Choose a class", class_names,
                     (int)(sizeof(class_names) / sizeof(class_names[0])));

--- a/src/pygame_adventure.py
+++ b/src/pygame_adventure.py
@@ -37,7 +37,7 @@ CLASS_ABILITIES: Dict[str, List[Ability]] = {
         Ability("Sneak Attack", "enemy", 4, True),
     ],
     "Mage": [Ability("Firebolt", "enemy", 4), Ability("Barrier", "ally", 3)],
-    "Healer": [Ability("Smite", "enemy", 3, True), Ability("Heal", "ally", 4)],
+    "Cleric": [Ability("Smite", "enemy", 3, True), Ability("Heal", "ally", 4)],
     "Beast": [Ability("Bite", "enemy", 2, True), Ability("Encourage", "ally", 2)],
     "Demon": [Ability("Claw", "enemy", 2, True)],
 }
@@ -46,7 +46,7 @@ CLASS_ATTRIBUTES: Dict[str, Attributes] = {
     "Fighter": Attributes(8, 4, 3, 12),
     "Rogue": Attributes(5, 8, 3, 10),
     "Mage": Attributes(3, 5, 8, 8),
-    "Healer": Attributes(4, 4, 8, 10),
+    "Cleric": Attributes(4, 4, 8, 10),
     "Beast": Attributes(6, 6, 2, 8),
     "Demon": Attributes(5, 5, 5, 10),
 }
@@ -58,7 +58,7 @@ ATTACK_ATTRIBUTE: Dict[str, str] = {
     "Fighter": "strength",
     "Rogue": "agility",
     "Mage": "wisdom",
-    "Healer": "wisdom",
+    "Cleric": "wisdom",
     "Beast": "strength",
     "Demon": "strength",
 }
@@ -67,7 +67,7 @@ DEFENSE_ATTRIBUTE: Dict[str, str] = {
     "Fighter": "strength",
     "Rogue": "agility",
     "Mage": "wisdom",
-    "Healer": "wisdom",
+    "Cleric": "wisdom",
     "Beast": "agility",
     "Demon": "strength",
 }
@@ -181,7 +181,7 @@ def get_face_surface(npc: NPC) -> pygame.Surface:
         draw_imp(surf, 16, 24)
     elif npc.char_class == "Fighter":
         draw_warrior(surf, 16, 48)
-    elif npc.char_class == "Healer":
+    elif npc.char_class == "Cleric":
         draw_cleric(surf, 16, 48)
     elif npc.char_class == "Rogue":
         draw_rogue(surf, 16, 48)
@@ -247,7 +247,7 @@ class NPC:
             draw_imp(screen, x, y)
         elif self.char_class == "Fighter":
             draw_warrior(screen, x, y)
-        elif self.char_class == "Healer":
+        elif self.char_class == "Cleric":
             draw_cleric(screen, x, y)
         elif self.char_class == "Rogue":
             draw_rogue(screen, x, y)
@@ -763,9 +763,9 @@ def create_rooms() -> Dict[str, Room]:
                 cleric_dialog,
                 False,
                 False,
-                "Healer",
-                CLASS_ABILITIES["Healer"].copy(),
-                CLASS_ATTRIBUTES["Healer"],
+                "Cleric",
+                CLASS_ABILITIES["Cleric"].copy(),
+                CLASS_ATTRIBUTES["Cleric"],
             ),
             NPC(
                 "Cultist",
@@ -834,8 +834,13 @@ def main() -> None:
     clock = pygame.time.Clock()
 
     name = text_input(screen, font, "Enter your name:")
-    class_idx = menu_prompt(screen, font, "Choose a class", ["Fighter", "Rogue", "Mage"])
-    char_class = ["Fighter", "Rogue", "Mage"][class_idx]
+    class_idx = menu_prompt(
+        screen,
+        font,
+        "Choose a class",
+        ["Fighter", "Rogue", "Mage", "Cleric"],
+    )
+    char_class = ["Fighter", "Rogue", "Mage", "Cleric"][class_idx]
     player = Player(
         320,
         240,


### PR DESCRIPTION
## Summary
- rename Healer class to Cleric across the project
- limit player class selection to Fighter, Rogue, Mage, or Cleric
- document Cleric option in the design doc

## Testing
- `python3 -m py_compile src/pygame_adventure.py`
- `ninja -v`

------
https://chatgpt.com/codex/tasks/task_e_68567dc671c08326bae2546bbce4c3c9