### PR TITLE
Update playable class list and note py port

### DIFF
--- a/docs/vertical_slice_design.md
+++ b/docs/vertical_slice_design.md
@@ -4,7 +4,7 @@ This document outlines the scope for the prototype.
 
 ## Features
 
-* **Character Creation:** Choose a name and class (Fighter, Rogue, Mage).
+* **Character Creation:** Choose a name and class (Fighter, Rogue, Mage, Healer).
 * **Exploration:** Navigate multiple text-based rooms connected by doors.
 * **Interactables:** Open chests and inspect objects to learn about the ship.
 * **Familiar Companion:** Discover a strange creature that can join you after a simple skill check.

--- a/nautiloid.c
+++ b/nautiloid.c
@@ -51,6 +51,7 @@ typedef enum {
     CLASS_DEMON
 } ClassId;
 #define CLASS_COUNT (CLASS_DEMON + 1)
+#define PLAYABLE_CLASS_COUNT 4
 
 static inline int __attribute__((unused))
 attribute_value(Attributes const *attributes, AttrKind kind) {
@@ -602,12 +603,12 @@ int main(int argc, char *argv[]) {
 
     char name[64];
     text_input(renderer, font, "Enter your name:", name, (int)sizeof(name));
-    char const *class_names[CLASS_COUNT];
-    for (int i = 0; i < CLASS_COUNT; ++i) {
+    char const *class_names[PLAYABLE_CLASS_COUNT];
+    for (int i = 0; i < PLAYABLE_CLASS_COUNT; ++i) {
         class_names[i] = classes[i].name;
     }
-    int class_idx =
-        menu_prompt(renderer, font, "Choose a class", class_names, CLASS_COUNT);
+    int class_idx = menu_prompt(renderer, font, "Choose a class", class_names,
+                                PLAYABLE_CLASS_COUNT);
     static char buffer[128];
     snprintf(buffer, sizeof(buffer), "Welcome %s the %s!", name,
              class_names[class_idx]);

--- a/src/pygame_adventure.py
+++ b/src/pygame_adventure.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+# NOTE: This file is retained while features are ported to nautiloid.c.
+# It no longer receives updates.
 # Postpone evaluation of type hints so forward references like `NPC` work
 
 import sys
@@ -884,8 +886,8 @@ def main() -> None:
     clock = pygame.time.Clock()
 
     name = text_input(screen, font, "Enter your name:")
-    class_idx = menu_prompt(screen, font, "Choose a class", ["Fighter", "Rogue", "Mage"])
-    char_class = ["Fighter", "Rogue", "Mage"][class_idx]
+    class_idx = menu_prompt(screen, font, "Choose a class", ["Fighter", "Rogue", "Mage", "Healer"])
+    char_class = ["Fighter", "Rogue", "Mage", "Healer"][class_idx]
     player = Player(
         320,
         240,


### PR DESCRIPTION
## Summary
- clarify in design doc that player can be a healer
- note that `pygame_adventure.py` is kept only while porting
- allow healer as a playable class in the Python demo
- restrict class menu in `nautiloid.c` to the four PC classes

## Testing
- `ninja -v`
- `python3 -m py_compile src/pygame_adventure.py`


------
https://chatgpt.com/codex/tasks/task_e_68568557d7648326b994acf4dbd9bb76