### PR TITLE
Center continue prompt

### DIFF
--- a/nautiloid.c
+++ b/nautiloid.c
@@ -220,16 +220,17 @@ draw_gradient_rect(SDL_Renderer *renderer, SDL_Rect rect,
 
 static void
 draw_text_box(SDL_Renderer *renderer, TTF_Font *font,
-              char const *lines[], int line_count) {
+              char const *lines[], int line_count,
+              char const *footer) {
     int   width  = 0;
     int   height = 0;
     SDL_GetRendererOutputSize(renderer, &width, &height);
     int        box_height = height / 3;
     SDL_Rect   rect       = {20, height - box_height - 20,
                              width - 40, box_height};
-    SDL_Color const top    = {100, 100, 255, 255},
-                       bottom = {40, 40, 180, 255};
-    draw_gradient_rect(renderer, rect, top, bottom);
+    SDL_Color const top       = {100, 100, 255, 255},
+                       botclr = {40, 40, 180, 255};
+    draw_gradient_rect(renderer, rect, top, botclr);
     SDL_SetRenderDrawColor(renderer, 192, 192, 192, 255);
     SDL_RenderDrawRect(renderer, &rect);
 
@@ -244,6 +245,17 @@ draw_text_box(SDL_Renderer *renderer, TTF_Font *font,
             SDL_DestroyTexture(text);
         }
         y += 26;
+    }
+    if (footer) {
+        SDL_Texture *text =
+            render_text(renderer, font, footer, (SDL_Color){255, 255, 255, 255});
+        if (text) {
+            SDL_Rect dst = {0, rect.y + rect.h - 26, 0, 0};
+            SDL_QueryTexture(text, NULL, NULL, &dst.w, &dst.h);
+            dst.x = rect.x + (rect.w - dst.w) / 2;
+            SDL_RenderCopy(renderer, text, NULL, &dst);
+            SDL_DestroyTexture(text);
+        }
     }
 }
 
@@ -264,13 +276,13 @@ show_message(SDL_Renderer *renderer, TTF_Font *font,
         }
         SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
         SDL_RenderClear(renderer);
-        char const *all[10];
+        char const *all[9];
         int         n = 0;
         for (int i = 0; i < line_count && i < 9; ++i) {
             all[n++] = lines[i];
         }
-        all[n++] = "Press SPACE or E to continue";
-        draw_text_box(renderer, font, all, n);
+        draw_text_box(renderer, font, all, n,
+                      "Press SPACE or E to continue");
         SDL_RenderPresent(renderer);
         SDL_Delay(16);
     }
@@ -302,7 +314,7 @@ menu_prompt(SDL_Renderer *renderer, TTF_Font *font, char const *question,
         }
         SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
         SDL_RenderClear(renderer);
-        draw_text_box(renderer, font, lines, option_count + 1);
+        draw_text_box(renderer, font, lines, option_count + 1, NULL);
         SDL_RenderPresent(renderer);
         SDL_Delay(16);
     }
@@ -489,7 +501,7 @@ text_input(SDL_Renderer *renderer, TTF_Font *font, char const *prompt,
         char const *lines[2] = {prompt, buffer};
         SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
         SDL_RenderClear(renderer);
-        draw_text_box(renderer, font, lines, 2);
+        draw_text_box(renderer, font, lines, 2, NULL);
         SDL_RenderPresent(renderer);
         SDL_Delay(16);
     }

--- a/src/pygame_adventure.py
+++ b/src/pygame_adventure.py
@@ -200,6 +200,7 @@ def draw_text_box(
     lines: List[str],
     speaker: Optional[str] = None,
     face: Optional[pygame.Surface] = None,
+    bottom: Optional[str] = None,
 ) -> None:
     width, height = screen.get_size()
     box_height = height // 3
@@ -220,6 +221,11 @@ def draw_text_box(
         face_rect = face.get_rect()
         face_rect.midright = (rect.x - 10, rect.y + 40)
         screen.blit(face, face_rect)
+    if bottom:
+        text = font.render(bottom, True, pygame.Color("white"))
+        text_rect = text.get_rect(centerx=rect.centerx)
+        text_rect.bottom = rect.bottom - 10
+        screen.blit(text, text_rect)
 
 
 @dataclass
@@ -281,7 +287,12 @@ def show_message(
         screen.fill((0, 0, 0))
         if draw_bg:
             draw_bg()
-        draw_text_box(screen, font, lines + ["Press SPACE or E to continue"])
+        draw_text_box(
+            screen,
+            font,
+            lines,
+            bottom="Press SPACE or E to continue",
+        )
         pygame.display.flip()
         clock.tick(30)
 


### PR DESCRIPTION
## Summary
- center the continue prompt in `draw_text_box` for SDL2/Pygame versions
- show the prompt using the new footer parameter

## Testing
- `python3 -m py_compile src/pygame_adventure.py`
- `ninja -v`

------
https://chatgpt.com/codex/tasks/task_e_68568764e0888326b248af1da86fd425