### PR TITLE
Add party menu and follower tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,5 @@
                corridor = {0};
 - Prefer to mark constant stack values `const` so changing values stand
   out, but avoid marking pointers themselves `const` unless necessary.
+
+- Omit defensive bounds or null checks for internal code; sanitizers will catch these bugs.

--- a/nautiloid.c
+++ b/nautiloid.c
@@ -577,9 +577,6 @@ npc_join(Player *player, Npc *npc) {
 
 static void
 npc_dismiss(Player *player, int index) {
-    if (index < 0 || index >= player->companion_count) {
-        return;
-    }
     player->companions[index]->joined = false;
     for (int i = index; i < player->companion_count - 1; ++i) {
         player->companions[i] = player->companions[i + 1];
@@ -602,9 +599,6 @@ show_party_menu(SDL_Renderer *renderer, TTF_Font *font, Player *player) {
     }
     int idx = menu_prompt(renderer, font, "Choose companion", options,
                           player->companion_count);
-    if (idx < 0 || idx >= player->companion_count) {
-        return;
-    }
     char const *acts[] = {"Talk", "Dismiss", "Back"};
     int action = menu_prompt(renderer, font, "Party action", acts, 3);
     if (action == 0) {


### PR DESCRIPTION
## Summary
- reduce follower speed and distance so they trail further behind
- add functions to dismiss companions and show the new party menu
- disable interaction with joined NPCs through the map
- show `[p] - party` in the instructions and handle the `p` key

## Testing
- `ninja -v`

------
https://chatgpt.com/codex/tasks/task_e_68568afe2c488326ae79dab13ab97937