### PR TITLE
Update UI hints with fun key highlights

### DIFF
--- a/nautiloid.c
+++ b/nautiloid.c
@@ -616,24 +616,24 @@ interaction_hint(Player const *player, Room const *room) {
     for (int i = 0; i < room->chests; ++i) {
         if (!room->chest[i].opened &&
             SDL_HasIntersection(&pr, &room->chest[i].rect)) {
-            return "open chest";
+            return "op[e]n chest";
         }
     }
     for (int i = 0; i < room->doors; ++i) {
         if (SDL_HasIntersection(&pr, &room->door[i].rect)) {
-            return "open door";
+            return "op[e]n door";
         }
     }
     for (int i = 0; i < room->props; ++i) {
         if (SDL_HasIntersection(&pr, &room->prop[i].rect)) {
-            return "inspect";
+            return "insp[e]ct";
         }
     }
     for (int i = 0; i < room->npcs; ++i) {
         if (!room->npc[i].joined) {
             SDL_Rect nr = {room->npc[i].x - 8, room->npc[i].y - 48, 16, 48};
             if (SDL_HasIntersection(&pr, &nr)) {
-                return "talk";
+                return "sp[e]ak";
             }
         }
     }
@@ -646,9 +646,9 @@ draw_instructions(SDL_Renderer *renderer, TTF_Font *font, char const *hint) {
     SDL_GetRendererOutputSize(renderer, &w, &h);
     char       buffer[64];
     if (hint) {
-        snprintf(buffer, sizeof(buffer), "[i] - inventory  [p] - party  [e] - %s", hint);
+        snprintf(buffer, sizeof(buffer), "[i]nventory  [p]arty  %s", hint);
     } else {
-        snprintf(buffer, sizeof(buffer), "[i] - inventory  [p] - party");
+        snprintf(buffer, sizeof(buffer), "[i]nventory  [p]arty");
     }
     SDL_Texture *text =
         render_text(renderer, font, buffer, (SDL_Color){255, 255, 255, 255});

--- a/src/pygame_adventure.py
+++ b/src/pygame_adventure.py
@@ -315,19 +315,19 @@ def interaction_hint(player: Player, room: Room) -> Optional[str]:
     pr = player.rect()
     for chest in room.chests:
         if not chest.opened and pr.colliderect(chest.rect):
-            return "open chest"
+            return "op[e]n chest"
     for door in room.doors:
         if pr.colliderect(door.rect):
-            return "open door"
+            return "op[e]n door"
     for prop in room.props:
         if pr.colliderect(prop.rect):
-            return "inspect"
+            return "insp[e]ct"
     for npc in room.npcs:
         if pr.colliderect(npc.rect()):
             if npc.enemy and not npc.joined:
-                return "fight"
+                return "engag[e]"
             if not npc.joined:
-                return "talk"
+                return "sp[e]ak"
     return None
 
 
@@ -1005,9 +1005,9 @@ def main() -> None:
         screen.blit(room_text, (10, 10))
 
         hint = interaction_hint(player, current)
-        lines = ["[i] - inventory"]
+        lines = ["[i]nventory", "[p]arty"]
         if hint:
-            lines.append(f"[e] - {hint}")
+            lines.append(hint)
         draw_instructions(screen, font, lines)
         pygame.display.flip()
         clock.tick(60)


### PR DESCRIPTION
## Summary
- add `[p]arty` instructions
- put the `[e]` key inside hint text
- adjust hint labels in python version to match

## Testing
- `ninja`
- `python3 -m py_compile src/pygame_adventure.py`


------
https://chatgpt.com/codex/tasks/task_e_68568db8ed5c8326ad06ca3717f5ce06