### PR TITLE
Implement speaker faces in SDL dialogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,5 @@
   out, but avoid marking pointers themselves `const` unless necessary.
 
 - Omit defensive bounds or null checks for internal code; sanitizers will catch these bugs.
+- Focus on matching `pygame_adventure.py` when completing TODO items. Put ideas
+  unrelated to feature parity in the FUTURE list.


### PR DESCRIPTION
## Summary
- support speaker names and faces in `draw_text_box`
- display NPC portraits in dialog menus
- note that FUTURE items are for post-Pygame parity work

## Testing
- `ninja -v`

------
https://chatgpt.com/codex/tasks/task_e_68568eeb974c83268e924de30a6bd24a