### PR TITLE
Use parentheses for key prompts

### DIFF
--- a/nautiloid.c
+++ b/nautiloid.c
@@ -679,24 +679,24 @@ interaction_hint(Player const *player, Room const *room) {
     for (int i = 0; i < room->chests; ++i) {
         if (!room->chest[i].opened &&
             SDL_HasIntersection(&pr, &room->chest[i].rect)) {
-            return "op[e]n chest";
+            return "op(e)n chest";
         }
     }
     for (int i = 0; i < room->doors; ++i) {
         if (SDL_HasIntersection(&pr, &room->door[i].rect)) {
-            return "op[e]n door";
+            return "op(e)n door";
         }
     }
     for (int i = 0; i < room->props; ++i) {
         if (SDL_HasIntersection(&pr, &room->prop[i].rect)) {
-            return "insp[e]ct";
+            return "insp(e)ct";
         }
     }
     for (int i = 0; i < room->npcs; ++i) {
         if (!room->npc[i].joined) {
             SDL_Rect nr = {room->npc[i].x - 8, room->npc[i].y - 48, 16, 48};
             if (SDL_HasIntersection(&pr, &nr)) {
-                return "sp[e]ak";
+                return "sp(e)ak";
             }
         }
     }
@@ -709,9 +709,9 @@ draw_instructions(SDL_Renderer *renderer, TTF_Font *font, char const *hint) {
     SDL_GetRendererOutputSize(renderer, &w, &h);
     char       buffer[64];
     if (hint) {
-        snprintf(buffer, sizeof(buffer), "[i]nventory  [p]arty  %s", hint);
+        snprintf(buffer, sizeof(buffer), "(i)nventory  (p)arty  %s", hint);
     } else {
-        snprintf(buffer, sizeof(buffer), "[i]nventory  [p]arty");
+        snprintf(buffer, sizeof(buffer), "(i)nventory  (p)arty");
     }
     SDL_Texture *text =
         render_text(renderer, font, buffer, (SDL_Color){255, 255, 255, 255});

--- a/src/pygame_adventure.py
+++ b/src/pygame_adventure.py
@@ -315,19 +315,19 @@ def interaction_hint(player: Player, room: Room) -> Optional[str]:
     pr = player.rect()
     for chest in room.chests:
         if not chest.opened and pr.colliderect(chest.rect):
-            return "op[e]n chest"
+            return "op(e)n chest"
     for door in room.doors:
         if pr.colliderect(door.rect):
-            return "op[e]n door"
+            return "op(e)n door"
     for prop in room.props:
         if pr.colliderect(prop.rect):
-            return "insp[e]ct"
+            return "insp(e)ct"
     for npc in room.npcs:
         if pr.colliderect(npc.rect()):
             if npc.enemy and not npc.joined:
-                return "engag[e]"
+                return "engag(e)"
             if not npc.joined:
-                return "sp[e]ak"
+                return "sp(e)ak"
     return None
 
 
@@ -1005,7 +1005,7 @@ def main() -> None:
         screen.blit(room_text, (10, 10))
 
         hint = interaction_hint(player, current)
-        lines = ["[i]nventory", "[p]arty"]
+        lines = ["(i)nventory", "(p)arty"]
         if hint:
             lines.append(hint)
         draw_instructions(screen, font, lines)


### PR DESCRIPTION
## Summary
- replace `[` and `]` with parentheses in displayed prompts

## Testing
- `python3 -m py_compile src/pygame_adventure.py`
- `ninja -v`


------
https://chatgpt.com/codex/tasks/task_e_685690d267f083268260b96b0e1fc6c2