### PR TITLE
Implement star-wars ending and sprite polish

### DIFF
--- a/nautiloid.c
+++ b/nautiloid.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 /*
  * TODO: port features from pygame_adventure.py
  * - Show floating damage numbers and health bars
@@ -297,6 +298,88 @@ show_message(SDL_Renderer *renderer, TTF_Font *font,
     }
 }
 
+typedef struct {
+    float     x;
+    float     y;
+    float     vy;
+    SDL_Color color;
+    int       life;
+} Firework;
+
+static void
+star_wars_scroll(SDL_Renderer *renderer, TTF_Font *font,
+                 char const *lines[], int line_count) {
+    int width  = 0;
+    int height = 0;
+    SDL_GetRendererOutputSize(renderer, &width, &height);
+    SDL_Texture *texts[16];
+    SDL_Rect     rects[16];
+    int          total = 0;
+    for (int i = 0; i < line_count && i < 16; ++i) {
+        texts[i] =
+            render_text(renderer, font, lines[i], (SDL_Color){255, 255, 0, 255});
+        rects[i] = (SDL_Rect){0, 0, 0, 0};
+        SDL_QueryTexture(texts[i], NULL, NULL, &rects[i].w, &rects[i].h);
+        rects[i].x = (width - rects[i].w) / 2;
+        total += rects[i].h + 8;
+    }
+    Firework fireworks[32];
+    int      fw_count = 0;
+    int      offset   = height;
+    int      hold     = 0;
+    bool     running  = true;
+    SDL_Event e;
+    while (running) {
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_QUIT) {
+                exit(0);
+            }
+        }
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+        if (fw_count < 32 && (rand() % 100) < 5) {
+            fireworks[fw_count] = (Firework){
+                (float)(50 + rand() % (width - 100)),
+                (float)height,
+                2.0f + (float)(rand() % 20) / 5.0f,
+                {(Uint8)(128 + rand() % 128),
+                 (Uint8)(128 + rand() % 128),
+                 (Uint8)(128 + rand() % 128),
+                 255},
+                0};
+            fw_count++;
+        }
+        for (int i = 0; i < fw_count; ++i) {
+            Firework *fw = &fireworks[i];
+            fw->y -= fw->vy;
+            fw->life++;
+            SDL_SetRenderDrawColor(renderer, fw->color.r, fw->color.g,
+                                   fw->color.b, 255);
+            SDL_RenderDrawPoint(renderer, (int)fw->x, (int)fw->y);
+            if (fw->life > 60) {
+                fireworks[i] = fireworks[--fw_count];
+                i--;
+            }
+        }
+        int y = offset;
+        for (int i = 0; i < line_count && i < 16; ++i) {
+            rects[i].y = y;
+            SDL_RenderCopy(renderer, texts[i], NULL, &rects[i]);
+            y += rects[i].h + 8;
+        }
+        SDL_RenderPresent(renderer);
+        SDL_Delay(16);
+        if (offset + total > 0) {
+            offset--;
+        } else if (++hold > 60) {
+            running = false;
+        }
+    }
+    for (int i = 0; i < line_count && i < 16; ++i) {
+        SDL_DestroyTexture(texts[i]);
+    }
+}
+
 static int
 menu_prompt(SDL_Renderer *renderer, TTF_Font *font, char const *question,
             char const *options[], int option_count,
@@ -347,20 +430,30 @@ draw_humanoid(SDL_Renderer *renderer, int x, int y, SDL_Color color) {
     SDL_RenderFillRect(renderer, &right_arm);
     SDL_RenderFillRect(renderer, &left_leg);
     SDL_RenderFillRect(renderer, &right_leg);
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_Rect eye1 = {x - 3, y - 46, 2, 2};
+    SDL_Rect eye2 = {x + 1, y - 46, 2, 2};
+    SDL_RenderFillRect(renderer, &eye1);
+    SDL_RenderFillRect(renderer, &eye2);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+    SDL_RenderDrawLine(renderer, x - 2, y - 42, x + 2, y - 42);
 }
 
 static void
 draw_warrior(SDL_Renderer *renderer, int x, int y) {
-    draw_humanoid(renderer, x, y, (SDL_Color){255, 0, 0, 255});
+    draw_humanoid(renderer, x, y, (SDL_Color){178, 34, 34, 255});
+    SDL_SetRenderDrawColor(renderer, 160, 82, 45, 255);
+    SDL_Rect band = {x - 5, y - 52, 10, 3};
+    SDL_RenderFillRect(renderer, &band);
     SDL_SetRenderDrawColor(renderer, 192, 192, 192, 255);
     SDL_RenderDrawLine(renderer, x + 6, y - 20, x + 10, y - 36);
 }
 
 static void
 draw_rogue(SDL_Renderer *renderer, int x, int y) {
-    draw_humanoid(renderer, x, y, (SDL_Color){34, 139, 34, 255});
+    draw_humanoid(renderer, x, y, (SDL_Color){107, 142, 35, 255});
     SDL_Rect hood = {x - 6, y - 48, 12, 8};
-    SDL_SetRenderDrawColor(renderer, 0, 100, 0, 255);
+    SDL_SetRenderDrawColor(renderer, 85, 107, 47, 255);
     SDL_RenderFillRect(renderer, &hood);
     SDL_SetRenderDrawColor(renderer, 192, 192, 192, 255);
     SDL_RenderDrawLine(renderer, x + 6, y - 20, x + 10, y - 30);
@@ -368,7 +461,13 @@ draw_rogue(SDL_Renderer *renderer, int x, int y) {
 
 static void
 draw_mage(SDL_Renderer *renderer, int x, int y) {
-    draw_humanoid(renderer, x, y, (SDL_Color){0, 0, 128, 255});
+    draw_humanoid(renderer, x, y, (SDL_Color){106, 90, 205, 255});
+    SDL_SetRenderDrawColor(renderer, 128, 0, 128, 255);
+    for (int i = 0; i < 12; ++i) {
+        int dx = i / 2;
+        SDL_RenderDrawLine(renderer, x - dx, y - 48 - i,
+                           x + dx, y - 48 - i);
+    }
     SDL_SetRenderDrawColor(renderer, 160, 82, 45, 255);
     SDL_RenderDrawLine(renderer, x + 6, y - 20, x + 6, y - 40);
     SDL_RenderDrawLine(renderer, x + 6, y - 40, x + 6, y - 42);
@@ -377,7 +476,10 @@ draw_mage(SDL_Renderer *renderer, int x, int y) {
 
 static void
 draw_cleric(SDL_Renderer *renderer, int x, int y) {
-    draw_humanoid(renderer, x, y, (SDL_Color){255, 255, 0, 255});
+    draw_humanoid(renderer, x, y, (SDL_Color){135, 206, 235, 255});
+    SDL_SetRenderDrawColor(renderer, 240, 230, 140, 255);
+    SDL_Rect hat = {x - 5, y - 52, 10, 2};
+    SDL_RenderFillRect(renderer, &hat);
     SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
     SDL_RenderDrawLine(renderer, x, y - 28, x, y - 44);
     SDL_RenderDrawLine(renderer, x - 4, y - 36, x + 4, y - 36);
@@ -825,7 +927,7 @@ game_end(SDL_Renderer *renderer, TTF_Font *font, Player const *player) {
             n++;
         }
     }
-    show_message(renderer, font, msgs, n);
+    star_wars_scroll(renderer, font, msgs, n);
 }
 
 int main(int argc, char *argv[]) {
@@ -841,6 +943,7 @@ int main(int argc, char *argv[]) {
         SDL_Quit();
         return 1;
     }
+    srand((unsigned)time(NULL));
 
     SDL_Window   *window   = NULL;
     SDL_Renderer *renderer = NULL;

--- a/src/pygame_adventure.py
+++ b/src/pygame_adventure.py
@@ -81,6 +81,9 @@ def draw_humanoid(screen: pygame.Surface, x: int, y: int, color: pygame.Color) -
     """Draw a 16x48 style humanoid sprite with (x, y) at the feet."""
     # head
     pygame.draw.rect(screen, color, pygame.Rect(x - 5, y - 48, 10, 10))
+    pygame.draw.rect(screen, pygame.Color("white"), pygame.Rect(x - 3, y - 46, 2, 2))
+    pygame.draw.rect(screen, pygame.Color("white"), pygame.Rect(x + 1, y - 46, 2, 2))
+    pygame.draw.rect(screen, pygame.Color("black"), pygame.Rect(x - 2, y - 42, 4, 1))
     # torso
     pygame.draw.rect(screen, color, pygame.Rect(x - 4, y - 38, 8, 20))
     # arms
@@ -93,13 +96,15 @@ def draw_humanoid(screen: pygame.Surface, x: int, y: int, color: pygame.Color) -
 
 def draw_warrior(screen: pygame.Surface, x: int, y: int) -> None:
     """Humanoid sprite with a small sword."""
-    draw_humanoid(screen, x, y, pygame.Color("red"))
+    draw_humanoid(screen, x, y, pygame.Color("firebrick"))
+    pygame.draw.rect(screen, pygame.Color("sienna"), pygame.Rect(x - 5, y - 52, 10, 3))
     pygame.draw.line(screen, pygame.Color("silver"), (x + 6, y - 20), (x + 10, y - 36), 2)
 
 
 def draw_cleric(screen: pygame.Surface, x: int, y: int) -> None:
     """Humanoid sprite with a holy symbol."""
-    draw_humanoid(screen, x, y, pygame.Color("yellow"))
+    draw_humanoid(screen, x, y, pygame.Color("skyblue"))
+    pygame.draw.rect(screen, pygame.Color("khaki"), pygame.Rect(x - 5, y - 52, 10, 2))
     pygame.draw.line(screen, pygame.Color("white"), (x, y - 28), (x, y - 44), 2)
     pygame.draw.line(screen, pygame.Color("white"), (x - 4, y - 36), (x + 4, y - 36), 2)
 
@@ -117,14 +122,19 @@ def draw_imp(screen: pygame.Surface, x: int, y: int) -> None:
 
 def draw_rogue(screen: pygame.Surface, x: int, y: int) -> None:
     """Humanoid sprite with a dagger and hood."""
-    draw_humanoid(screen, x, y, pygame.Color("forestgreen"))
-    pygame.draw.rect(screen, pygame.Color("darkgreen"), pygame.Rect(x - 6, y - 48, 12, 8))
+    draw_humanoid(screen, x, y, pygame.Color("olivedrab"))
+    pygame.draw.rect(screen, pygame.Color("darkolivegreen"), pygame.Rect(x - 6, y - 48, 12, 8))
     pygame.draw.line(screen, pygame.Color("silver"), (x + 6, y - 20), (x + 10, y - 30), 2)
 
 
 def draw_mage(screen: pygame.Surface, x: int, y: int) -> None:
     """Humanoid sprite with a staff."""
-    draw_humanoid(screen, x, y, pygame.Color("navy"))
+    draw_humanoid(screen, x, y, pygame.Color("slateblue"))
+    pygame.draw.polygon(
+        screen,
+        pygame.Color("purple"),
+        [(x - 6, y - 48), (x + 6, y - 48), (x, y - 60)],
+    )
     pygame.draw.line(screen, pygame.Color("sienna"), (x + 6, y - 20), (x + 6, y - 40), 2)
     pygame.draw.circle(screen, pygame.Color("sienna"), (x + 6, y - 42), 3)
 
@@ -308,6 +318,54 @@ def show_inventory(
     else:
         lines = ["Your inventory is empty."]
     show_message(screen, font, lines)
+
+
+def star_wars_scroll(screen: pygame.Surface, font: pygame.font.Font, lines: List[str]) -> None:
+    """Scroll lines upward with simple fireworks."""
+    clock = pygame.time.Clock()
+    surfaces = [font.render(line, True, pygame.Color("yellow")) for line in lines]
+    total_h = sum(s.get_height() + 8 for s in surfaces)
+    offset = screen.get_height()
+    fireworks: List[dict] = []
+    hold = 0
+    while offset + total_h > 0 or hold < 60:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+        screen.fill((0, 0, 0))
+        if random.random() < 0.05:
+            fireworks.append(
+                {
+                    "x": random.randint(50, screen.get_width() - 50),
+                    "y": screen.get_height(),
+                    "vy": random.uniform(2.0, 4.0),
+                    "color": pygame.Color(
+                        random.randint(128, 255),
+                        random.randint(128, 255),
+                        random.randint(128, 255),
+                    ),
+                    "life": 0,
+                }
+            )
+        for fw in fireworks[:]:
+            fw["y"] -= fw["vy"]
+            fw["life"] += 1
+            pygame.draw.circle(screen, fw["color"], (int(fw["x"]), int(fw["y"])), 2)
+            if fw["life"] > 60:
+                fireworks.remove(fw)
+        y = offset
+        for surf in surfaces:
+            rect = surf.get_rect(centerx=screen.get_width() // 2)
+            rect.y = y
+            screen.blit(surf, rect)
+            y += surf.get_height() + 8
+        pygame.display.flip()
+        clock.tick(60)
+        if offset + total_h > 0:
+            offset -= 1
+        else:
+            hold += 1
 
 
 def interaction_hint(player: Player, room: Room) -> Optional[str]:
@@ -886,7 +944,7 @@ def game_end(screen: pygame.Surface, font: pygame.font.Font, player: Player) -> 
         lines.append("Inventory:")
         for item in player.inventory:
             lines.append(f" - {item}")
-    show_message(screen, font, lines)
+    star_wars_scroll(screen, font, lines)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- scroll the final screen with `star_wars_scroll`
- draw eyes and mouths on humanoids
- give each class distinct colors and accessories
- call `srand` on startup for fireworks

## Testing
- `python3 -m py_compile src/pygame_adventure.py`
- `ninja`


------
https://chatgpt.com/codex/tasks/task_e_68569f6460f88326accf06be2a0e917c