### PR TITLE
Add sprint feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ Build it with `ninja` to produce `out/nautiloid`.
 It now uses SDL_ttf and the bundled Final Fantasy font for on-screen text.
 The program has started porting the Python entity system with simple class data
 and sprite rendering.
+Hold Shift while moving to sprint across rooms.
 

--- a/nautiloid.c
+++ b/nautiloid.c
@@ -1492,9 +1492,11 @@ draw_instructions(SDL_Renderer *renderer, TTF_Font *font, char const *hint) {
     SDL_GetRendererOutputSize(renderer, &w, &h);
     char       buffer[64];
     if (hint) {
-        snprintf(buffer, sizeof(buffer), "i - inventory  p - party  %s", hint);
+        snprintf(buffer, sizeof(buffer),
+                 "i - inventory  p - party  shift - sprint  %s", hint);
     } else {
-        snprintf(buffer, sizeof(buffer), "i - inventory  p - party");
+        snprintf(buffer, sizeof(buffer),
+                 "i - inventory  p - party  shift - sprint");
     }
     SDL_Texture *text =
         render_text(renderer, font, buffer, (SDL_Color){255, 255, 255, 255});
@@ -1729,18 +1731,22 @@ int main(int argc, char *argv[]) {
                 }
             }
         }
-        const Uint8 *keys = SDL_GetKeyboardState(NULL);
+        const Uint8 *keys  = SDL_GetKeyboardState(NULL);
+        int          speed = 4;
+        if (keys[SDL_SCANCODE_LSHIFT] || keys[SDL_SCANCODE_RSHIFT]) {
+            speed = 8;
+        }
         if (keys[SDL_SCANCODE_LEFT]) {
-            player.x -= 4;
+            player.x -= speed;
         }
         if (keys[SDL_SCANCODE_RIGHT]) {
-            player.x += 4;
+            player.x += speed;
         }
         if (keys[SDL_SCANCODE_UP]) {
-            player.y -= 4;
+            player.y -= speed;
         }
         if (keys[SDL_SCANCODE_DOWN]) {
-            player.y += 4;
+            player.y += speed;
         }
         if (player.x < 20) {
             player.x = 20;


### PR DESCRIPTION
## Summary
- add sprint movement speed to player controls
- show 'shift - sprint' in on-screen instructions
- document sprint controls in README

## Testing
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_6857243f9ba08326b2cbe9263d696950