### PR TITLE
Remove port notes from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,5 @@
   out, but avoid marking pointers themselves `const` unless necessary.
 
 - Omit defensive bounds or null checks for internal code; sanitizers will catch these bugs.
-- Focus on matching `pygame_adventure.py` when completing TODO items. Put ideas
-  unrelated to feature parity in the FUTURE list.
+- Track open work with TODO comments directly in the code.
 - Do not use `__attribute__((unused))`; remove unused code instead.

--- a/README.md
+++ b/README.md
@@ -5,15 +5,12 @@ The scenario resembles an escape from a nautiloid ship with original characters 
 The goal is to demonstrate core gameplay features in a small vertical slice.
 
 See `docs/vertical_slice_design.md` for the design overview.
-The old text-based demo has been removed. A short Pygame version was used
-while porting features but has now been retired after merging its mechanics
-into the SDL2 prototype.
+The old text-based and Pygame demos were removed once the SDL2 prototype covered their mechanics.
 
 ## SDL2 Prototype
 A minimal C/SDL2 prototype resides in `nautiloid.c`.
 Build it with `ninja` to produce `out/nautiloid`.
 It now uses SDL_ttf and the bundled Final Fantasy font for on-screen text.
-The program has started porting the Python entity system with simple class data
-and sprite rendering.
+The program includes a basic entity system with simple class data and sprite rendering.
 Hold Shift while moving to sprint across rooms.
 

--- a/nautiloid.c
+++ b/nautiloid.c
@@ -11,12 +11,7 @@
 #define PI 3.14159265358979323846
 #endif
 /*
- * Features ported from pygame_adventure.py
- * - Floating damage numbers and health bars
- * - Turn-based combat via combat_encounter()
- * - Moving between rooms and interacting with objects
- *
- * FUTURE
+ * TODO
  * - Use SDL_image to load textured sprites
  * - Add pathfinding for NPC movement
  * - Implement save/load functionality


### PR DESCRIPTION
## Summary
- cut README mentions of porting from Pygame
- trim `nautiloid.c` header comment to just TODOs

## Testing
- `ninja -n`
- `ninja`


------
https://chatgpt.com/codex/tasks/task_e_68572765d8c483268947eb5bc8e5cc83